### PR TITLE
Implement mission joining, leaving - Actions && Switch badges for Missions, Display joined missions in My profile -

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -8,21 +8,53 @@ import Table from 'react-bootstrap/Table';
 import Button from 'react-bootstrap/Button';
 import Badge from 'react-bootstrap/Badge';
 
+import store from '../redux/configureStore';
+import { reserveMission, cancelMissionReservation } from '../redux/missions/missions';
+
 export default function Missions() {
-  // get missions data from the store
   const missions = useSelector((state) => state.missions);
+
+  const handleClick = (mission) => (e) => {
+    if (e.target.textContent === 'Join Mission') {
+      store.dispatch(reserveMission(mission));
+    } else if (e.target.textContent === 'Leave Mission') {
+      store.dispatch(cancelMissionReservation(mission));
+    }
+  };
 
   const missionList = missions.map((mission) => (
     <tr key={mission.id}>
-      <td>{mission.mission_name}</td>
+      <th className="align-middle">{mission.mission_name}</th>
       <td>{mission.description}</td>
-      <td>
-        <Badge bg="success" className="me-2">
-          Active Member
-        </Badge>
+      <td className="align-middle">
+        {!mission.reserved && (
+          <Badge bg="secondary" className="me-2">Not a member</Badge>
+        )}
+
+        {mission.reserved && (
+          <Badge bg="success" className="me-2">Active Member</Badge>
+        )}
       </td>
-      <td>
-        <Button variant="outline-secondary">Join Mission</Button>
+      <td className="align-middle">
+        {!mission.reserved && (
+          <Button
+            className="text-nowrap"
+            variant="outline-secondary"
+            onClick={handleClick(mission)}
+          >
+            Join Mission
+          </Button>
+        )}
+
+        {mission.reserved && (
+          <Button
+            className="text-nowrap"
+            variant="outline-danger"
+            onClick={handleClick(mission)}
+          >
+            Leave Mission
+          </Button>
+        )}
       </td>
     </tr>
   ));

--- a/src/components/MyProfile.js
+++ b/src/components/MyProfile.js
@@ -1,9 +1,40 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import ListGroup from 'react-bootstrap/ListGroup';
 
 export default function MyProfile() {
+  const rockets = useSelector((state) => state.rockets);
+  const reservedRockets = rockets.filter((rocket) => rocket.reserved);
+
+  const myRockets = reservedRockets.map((rocket) => (
+    <ListGroup.Item key={rocket.id}>
+      {rocket.rocket_name}
+    </ListGroup.Item>
+  ));
+
+  const myMissions = [];
+
   return (
-    <div>
-      <h1>My Profile</h1>
-    </div>
+    <Container className="container-xl">
+      <Row className="mt-4">
+        <Col>
+          <h2>My Missions</h2>
+          <ListGroup>
+            {myMissions}
+          </ListGroup>
+        </Col>
+
+        <Col>
+          <h2>My Rockets</h2>
+          <ListGroup>
+            {myRockets}
+          </ListGroup>
+        </Col>
+      </Row>
+    </Container>
   );
 }

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,8 +1,8 @@
 import api from '../../api/SpaceXAPI';
 
 const GET_MISSIONS_FROM_API = 'missions/GET_MISSIONS_FROM_API';
-
-// Initial state
+const RESERVE_MISSION = 'missions/RESERVE_MISSION';
+const CANCEL_MISSION_RESERVATION = 'missions/CANCEL_MISSION_RESERVATION';
 
 const initialState = [];
 
@@ -26,12 +26,47 @@ export const getMissionsFromApi = () => ((dispatch) => {
     });
 });
 
+export const reserveMission = (payload) => ({
+  type: RESERVE_MISSION,
+  payload,
+});
+
+export const cancelMissionReservation = (payload) => ({
+  type: CANCEL_MISSION_RESERVATION,
+  payload,
+});
+
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case GET_MISSIONS_FROM_API:
       return [
         ...action.payload,
       ];
+
+    case RESERVE_MISSION: {
+      const newState = state.map((mission) => {
+        if (mission.id !== action.payload.id) {
+          return mission;
+        }
+        return { ...mission, reserved: true };
+      });
+      return [
+        ...newState,
+      ];
+    }
+
+    case CANCEL_MISSION_RESERVATION: {
+      const newState = state.map((mission) => {
+        if (mission.id !== action.payload.id) {
+          return mission;
+        }
+        return { ...mission, reserved: false };
+      });
+      return [
+        ...newState,
+      ];
+    }
+
     default:
       return state;
   }


### PR DESCRIPTION
- Render a list of all joined missions (use filter()) on the "My profile" page.
- Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
- When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state
- Follow the same logic as with the "Join mission" - but you need to set the reserved key to false.
- Dispatch these actions upon click on the corresponding buttons.
